### PR TITLE
Expose action immutable properties for access in observers

### DIFF
--- a/src/Action.swift
+++ b/src/Action.swift
@@ -9,14 +9,14 @@ public protocol ActionType { }
 public struct Action<A: ActionType> {
   /// The action associated to this status object.
   /// -note: Typically an extensible enum.
-  let action: A
+  public let action: A
   /// The state of the action.
-  let model: ActionState
+  public let model: ActionState
   /// The last time the operation was being executed.
-  let lastRun: TimeInterval
+  public let lastRun: TimeInterval
   /// Additional info passed from the action.
   /// - note: Don't use this field to model action arguments.
-  let userInfo: [String: Any]?
+  public let userInfo: [String: Any]?
 }
 
 public enum ActionState {

--- a/src/Store.swift
+++ b/src/Store.swift
@@ -54,7 +54,7 @@ public protocol StoreType: class {
 
 open class Store<S: ModelType, A: ActionType>: StoreType {
   /// The block executed whenever the store changes.
-  public typealias OnChange = (S, Action<A>) -> (Void)
+  public typealias OnChange = (S, Action<A>?) -> (Void)
   /// The current state for the Store.
   public private(set) var model: S
   /// Opaque reference to the model wrapped by this store.
@@ -78,9 +78,13 @@ open class Store<S: ModelType, A: ActionType>: StoreType {
   /// - note: The same observer can be added several times with different *onChange* blocks.
   public func register(observer: AnyObject, onChange: @escaping OnChange) {
     precondition(Thread.isMainThread)
+
     let observer = StoreObserver<S, A>(observer, closure: onChange)
     observers = observers.filter { $0.ref != nil }
     observers.append(observer)
+    
+    // Notify observer immediately upon registration
+    observer.closure(self.model, nil)
   }
 
   /// Unregister the observer passed as argument.


### PR DESCRIPTION
Want to be able to inspect the action in the observer. Currently, none of the action properties are accessible outside of the module, thus the action itself doesn't do much. Wanting to do something like this:

```
store.register(observer: self) { model, action in
    switch action.action {
        case CounterAction.increment:
            // specific code path
        default: break
    }
}
```