### PR TITLE
adds ios v13 as platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "Store",
+    platforms: [
+        .iOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
I don't know if this is a bug oder Feature in the SPM, but archive fails on an ios app (target v13) if the requirements are not set within the Package definition because it does not find `Combine`:

```
[13:42:48]: $ set -o pipefail && xcodebuild -workspace ./Project.xcworkspace -scheme Project_iOS -configuration Beta -destination 'generic/platform=iOS' -archivePath /Users/myUser/Library/Developer/Xcode/Archives/2020-01-30/MyApp_1.0.0\ 2020-01-30\ 13.42.48.xcarchive clean archive | tee /Users/myUser/Library/Logs/gym/MyApp_iOS-MyApp_iOS.log | xcpretty
[13:42:50]: ▸ Clean Succeeded
[13:42:52]: ▸ ❌  /Users/myUser/Library/Developer/Xcode/DerivedData/MyApp-bzoezqhsrgpxbigijhtfbdkeuqyx/SourcePackages/checkouts/Store/Sources/Store/Action.swift:1:8: no such module 'Combine'
[13:42:52]: ▸ import Combine
[13:42:52]: ▸        ^
[13:42:53]: ▸ ** ARCHIVE FAILED **
[13:42:53]: ▸ The following build commands failed:
[13:42:53]: ▸ 	CompileSwift normal armv7
[13:42:53]: ▸ 	CompileSwiftSources normal armv7 com.apple.xcode.tools.swift.compiler
[13:42:53]: ▸ 	CompileSwift normal arm64
[13:42:53]: ▸ (3 failures)
▸ Clean Succeeded

❌  /Users/myUser/Library/Developer/Xcode/DerivedData/MyApp-bzoezqhsrgpxbigijhtfbdkeuqyx/SourcePackages/checkouts/Store/Sources/Store/Action.swift:1:8: no such module 'Combine'

import Combine
       ^


** ARCHIVE FAILED **
```