### PR TITLE
Fix typos and compiler warnings (Swift 5.2)

### DIFF
--- a/Sources/Store/Operations.swift
+++ b/Sources/Store/Operations.swift
@@ -41,11 +41,11 @@ open class AsyncOperation: Operation {
   public typealias CompletionBlock = () -> Void
 
   // Internal properties override.
-  @objc dynamic override public var isAsynchronous: Bool { return true }
+  @objc dynamic override public var isAsynchronous: Bool { true }
 
-  @objc dynamic override public var isConcurrent: Bool { return true }
-  @objc dynamic override public var isExecuting: Bool { return __executing }
-  @objc dynamic override public var isFinished: Bool { return __finished }
+  @objc dynamic override public var isConcurrent: Bool { true }
+  @objc dynamic override public var isExecuting: Bool { __executing }
+  @objc dynamic override public var isFinished: Bool { __finished }
 
   // __ to avoid name clashes with the superclass.
   @objc dynamic private var __executing = false {

--- a/Sources/Store/SerializableStore.swift
+++ b/Sources/Store/SerializableStore.swift
@@ -10,16 +10,16 @@ open class SerializableStore<M: SerializableModelProtocol>: Store<M> {
     /// Does not compute any diff.
     case none
 
-    /// Computes the diff synchrously right after the transaction has completed.
+    /// Computes the diff synchronously right after the transaction has completed.
     case sync
 
-    /// Computes the diff asynchrously (in a serial queue) when transaction is completed.
+    /// Computes the diff asynchronously (in a serial queue) when transaction is completed.
     case async
   }
 
   /// Publishes a stream with the model changes caused by the last transaction.
   @Published public var lastTransactionDiff: TransactionDiff = TransactionDiff(
-    transaction: SignpostTransaction(singpost: Signpost.prior),
+    transaction: SignpostTransaction(signpost: Signpost.prior),
     diffs: [:])
 
   /// Where the diffing routine should be dispatched.
@@ -40,8 +40,8 @@ open class SerializableStore<M: SerializableModelProtocol>: Store<M> {
     self._lastModelSnapshot = model.encodeFlatDictionary()
   }
 
-  override open func reduceModel(transaction: TransactionProtocol?, closure: (inout M) -> (Void)) {
-    let transaction = transaction ?? SignpostTransaction(singpost: Signpost.modelUpdate)
+  override open func reduceModel(transaction: TransactionProtocol?, closure: (inout M) -> Void) {
+    let transaction = transaction ?? SignpostTransaction(signpost: Signpost.modelUpdate)
     super.reduceModel(transaction: transaction, closure: closure)
   }
 
@@ -83,7 +83,7 @@ open class SerializableStore<M: SerializableModelProtocol>: Store<M> {
 
       os_log(
         .debug, log: OSLog.diff, "▩ 𝘿𝙄𝙁𝙁 (%s) %s %s",
-        transaction.id, transaction.actionId, diffs.storeDebugDecription(short: true))
+        transaction.id, transaction.actionId, diffs.storeDebugDescription(short: true))
     }
   }
 }
@@ -117,7 +117,7 @@ extension SerializableModelProtocol {
 
   /// Decodes the model from a dictionary.
   public static func decode(dictionary: EncodedDictionary) -> Self {
-    return _deserialize(dictionary: dictionary)
+    _deserialize(dictionary: dictionary)
   }
 }
 

--- a/Sources/Store/Serialization/Signpost.swift
+++ b/Sources/Store/Serialization/Signpost.swift
@@ -41,8 +41,8 @@ public final class SignpostTransaction: TransactionProtocol {
     return self
   }
 
-  init(singpost: String) {
-    self.actionId = singpost
+  init(signpost: String) {
+    self.actionId = signpost
   }
 
   public func perform(operation: AsyncOperation) {

--- a/Sources/Store/Serialization/TransactionDiff.swift
+++ b/Sources/Store/Serialization/TransactionDiff.swift
@@ -19,7 +19,7 @@ public final class Query {
     FlatEncoding.KeyPath(segments: segments)
   }
 
-  /// Returns `true` if the key path was added in this transaction, `false` otherwsie.
+  /// Returns `true` if the key path was added in this transaction, `false` otherwise.
   public func toPropertyDiff() -> PropertyDiff {
     transactionDiff.diffs[self.toKeyPath()] ?? .unspecified
   }
@@ -56,12 +56,12 @@ public struct TransactionDiff {
 
   /// Returns the `diffs` map encoded as **JSON** data.
   public var json: Data {
-    return (try? sharedJSONEncoder.encode(diffs)) ?? Data()
+    (try? sharedJSONEncoder.encode(diffs)) ?? Data()
   }
 
   /// Queries the diff collection for a keypath change.
   public func query(_ keyPath: (Query) -> Query) -> PropertyDiff {
-    return keyPath(Query(transactionDiff: self)).toPropertyDiff()
+    keyPath(Query(transactionDiff: self)).toPropertyDiff()
   }
 
   public init(transaction: TransactionProtocol, diffs: [FlatEncoding.KeyPath: PropertyDiff]) {
@@ -80,7 +80,7 @@ public enum PropertyDiff {
   case removed
   case unspecified
 
-  /// Returns `true` if the key path was added in this transaction, `false` otherwsie.
+  /// Returns `true` if the key path was added in this transaction, `false` otherwise.
   @inlinable @inline(__always)
   public func isAdded() -> Bool {
     switch self {
@@ -89,7 +89,7 @@ public enum PropertyDiff {
     }
   }
 
-  /// Returns `true` if the key path was remvoed in this transaction, `false` otherwsie.
+  /// Returns `true` if the key path was removed in this transaction, `false` otherwise.
   @inlinable @inline(__always)
   public func isRemoved() -> Bool {
     switch self {
@@ -98,7 +98,7 @@ public enum PropertyDiff {
     }
   }
 
-  /// Returns `true` if the key path was chnaged in this transaction, `false` otherwsie.
+  /// Returns `true` if the key path was changed in this transaction, `false` otherwise.
   @inlinable @inline(__always)
   public func isChanged() -> Bool {
     switch self {
@@ -116,7 +116,7 @@ public enum PropertyDiff {
     }
   }
 
-  /// Returns the touple (`old`, `new`) if the value of the property changed in this transaction.
+  /// Returns the tuple (`old`, `new`) if the value of the property changed in this transaction.
   @inlinable @inline(__always)
   public func asNewAddedValue<T: Codable>() -> (T, T)? {
     switch self {
@@ -166,7 +166,7 @@ public enum FlatEncoding {
 
     /// Whether this is an empty KeyPath or not.
     public var isEmpty: Bool {
-      return segments.isEmpty
+      segments.isEmpty
     }
 
     /// The raw string for this KeyPath.
@@ -210,13 +210,13 @@ public enum FlatEncoding {
 
     /// The raw string for this KeyPath.
     public var description: String {
-      return path
+      path
     }
   }
 
   // MARK: - Private
 
-  /// Intermediate dictionary represntation for `EncodedDictionary` ⇒ `FlatEncoding.Dictionary`
+  /// Intermediate dictionary representation for `EncodedDictionary` ⇒ `FlatEncoding.Dictionary`
   fileprivate enum Node {
     case dictionary(_ dictionary: EncodedDictionary)
     case array(_ array: [Any])
@@ -310,7 +310,7 @@ extension PropertyDiff: CustomStringConvertible, Encodable {
 
 extension Dictionary where Key == FlatEncoding.KeyPath, Value == PropertyDiff {
   /// Debug description for a change set.
-  func storeDebugDecription(short: Bool) -> String {
+  func storeDebugDescription(short: Bool) -> String {
     let keys = self.keys.map { $0.path }.sorted()
     let threshold = 8
     let noChangesLeft = keys.count - threshold

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -30,7 +30,7 @@ public protocol StoreProtocol: AnyStoreProtocol {
   var model: ModelType { get }
 
   /// Atomically update the model.
-  func reduceModel(transaction: TransactionProtocol?, closure: (inout ModelType) -> (Void))
+  func reduceModel(transaction: TransactionProtocol?, closure: (inout ModelType) -> Void)
 }
 
 open class Store<M>: StoreProtocol, ObservableObject {
@@ -38,12 +38,12 @@ open class Store<M>: StoreProtocol, ObservableObject {
   @Published public private(set) var model: M
 
   /// Opaque reference to the model wrapped by this store.
-  public var opaqueModelRef: Any { return model }
+  public var opaqueModelRef: Any { model }
 
   /// All of the registered middleware.
   public var middleware: [Middleware] = []
 
-  /// Syncronizes the access to the state object.
+  /// Synchronizes the access to the state object.
   private var _stateLock = SpinLock()
 
   public init(model: M) {
@@ -51,7 +51,7 @@ open class Store<M>: StoreProtocol, ObservableObject {
   }
 
   /// Atomically update the model.
-  open func reduceModel(transaction: TransactionProtocol? = nil, closure: (inout M) -> (Void)) {
+  open func reduceModel(transaction: TransactionProtocol? = nil, closure: (inout M) -> Void) {
     self._stateLock.lock()
     let old = self.model
     let new = assign(model, changes: closure)
@@ -121,12 +121,12 @@ open class Store<M>: StoreProtocol, ObservableObject {
     throttle: TimeInterval = 0,
     handler: Dispatcher.TransactionCompletionHandler = nil
   ) -> Transaction<A> where A.AssociatedStoreType: Store<M> {
-    let tranctionObj = transaction(action: action, mode: mode)
-    tranctionObj.run(handler: handler)
+    let transactionObj = transaction(action: action, mode: mode)
+    transactionObj.run(handler: handler)
     if throttle > TimeInterval.ulpOfOne {
-      tranctionObj.throttle(throttle)
+      transactionObj.throttle(throttle)
     }
-    return tranctionObj
+    return transactionObj
   }
 
   @discardableResult @inlinable @inline(__always)

--- a/Sources/Store/Transaction.swift
+++ b/Sources/Store/Transaction.swift
@@ -41,7 +41,7 @@ public protocol TransactionProtocol: class, TransactionConvertible {
   /// Trackable `@Published` property.
   var state: TransactionState { get set }
 
-  /// Returns the aynchronous operation that is going to be executed with this transaction.
+  /// Returns the asynchronous operation that is going to be executed with this transaction.
   var operation: AsyncOperation { get }
 
   /// Dispatch strategy modifier.
@@ -91,7 +91,7 @@ public final class Transaction<A: ActionProtocol>: TransactionProtocol, Identifi
     get { store }
   }
   
-  /// Stored handeler.
+  /// Stored handler.
   private var _handler: Dispatcher.TransactionCompletionHandler = nil
 
   /// Represents the progress of the transaction.
@@ -101,7 +101,7 @@ public final class Transaction<A: ActionProtocol>: TransactionProtocol, Identifi
     }
   }
 
-  /// Returns the aynchronous operation that is going to be executed with this transaction.
+  /// Returns the asynchronous operation that is going to be executed with this transaction.
   public lazy var operation: AsyncOperation = {
     let operation = TransactionOperation(transaction: self)
     operation._finishBlock = { [weak self] in


### PR DESCRIPTION
Very minor updates:

- Fixed typos.
- Removed redundant `return` statements.