### PR TITLE
Expose Transaction.init(action:store:)

### DIFF
--- a/Sources/Store/Transaction.swift
+++ b/Sources/Store/Transaction.swift
@@ -120,7 +120,7 @@ public final class Transaction<A: ActionProtocol>: TransactionProtocol, Identifi
   /// The action associated with this transaction.
   public let action: A
 
-  init(_ action: A, in store: A.AssociatedStoreType? = nil) {
+  public init(_ action: A, in store: A.AssociatedStoreType? = nil) {
     self.store = store
     self.action = action
   }


### PR DESCRIPTION
This is currently private, and causes errors: `initializer is inaccessible due to 'internal' protection level`.

Exposing it brings the code up to date with the documentation in the Readme.